### PR TITLE
Solving Migration Error on MySQL Version 5.6

### DIFF
--- a/migrations/2016_02_07_000000_create_likeable_tables.php
+++ b/migrations/2016_02_07_000000_create_likeable_tables.php
@@ -10,7 +10,7 @@ class CreateLikeableTables extends Migration
     {
         Schema::create('likeable_likes', function (Blueprint $table) {
             $table->bigIncrements('id');
-            $table->morphs('likeable');
+            $table->uuidMorphs('likeable');
             $table->string('user_id', 36)->index();
             $table->timestamps();
             $table->unique(['likeable_id', 'likeable_type', 'user_id'], 'likeable_likes_unique');
@@ -18,7 +18,7 @@ class CreateLikeableTables extends Migration
 
         Schema::create('likeable_like_counters', function (Blueprint $table) {
             $table->bigIncrements('id');
-            $table->morphs('likeable');
+            $table->uuidMorphs('likeable');
             $table->unsignedBigInteger('count')->default(0);
             $table->unique(['likeable_id', 'likeable_type'], 'likeable_counts');
         });

--- a/migrations/2016_02_07_000000_create_likeable_tables.php
+++ b/migrations/2016_02_07_000000_create_likeable_tables.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
 
 class CreateLikeableTables extends Migration
 {
@@ -9,17 +10,15 @@ class CreateLikeableTables extends Migration
     {
         Schema::create('likeable_likes', function (Blueprint $table) {
             $table->bigIncrements('id');
-            $table->string('likeable_id', 36);
-            $table->string('likeable_type', 255);
+            $table->morphs('likeable');
             $table->string('user_id', 36)->index();
             $table->timestamps();
             $table->unique(['likeable_id', 'likeable_type', 'user_id'], 'likeable_likes_unique');
         });
-        
+
         Schema::create('likeable_like_counters', function (Blueprint $table) {
             $table->bigIncrements('id');
-            $table->string('likeable_id', 36);
-            $table->string('likeable_type', 255);
+            $table->morphs('likeable');
             $table->unsignedBigInteger('count')->default(0);
             $table->unique(['likeable_id', 'likeable_type'], 'likeable_counts');
         });


### PR DESCRIPTION
On MYSQL 5.6  when migrating you get an error: Syntax error or access violation: 

**1071 Specified key was too long; max key length is 767 bytes.**

to solve it update the migration file by changing the columns likeable_id and likeable_type 
```
change from
$table->string('likeable_id', 36);
$table->string('likeable_type', 255);

to
$table->morphs('likeable')
```
and the error is solved